### PR TITLE
Fetch missions data, Make sure we only display data once

### DIFF
--- a/src/components/Missions/Missions.jsx
+++ b/src/components/Missions/Missions.jsx
@@ -1,7 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+import getMissions from '../../redux/missions/missionsApi';
 
-const Missions = () => (
-  <div>Missions</div>
-);
+const Missions = () => {
+  const dispatch = useDispatch();
+  const missions = useSelector((state) => state.missions, shallowEqual);
+  useEffect(() => {
+    if (missions.length === 0) {
+      // avoid fetch data in every createComponent
+      dispatch(getMissions());
+    }
+  });
+  console.log('missions', missions);
+  return (
+    <div>Missions</div>
+  );
+};
 
 export default Missions;

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
 import './styles/_global.scss';
 import App from './components/App/App';
 import reportWebVitals from './reportWebVitals';
+import store from './redux/configStore';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
 );
 

--- a/src/redux/configStore.js
+++ b/src/redux/configStore.js
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import missionsReducer from './missions/missions';
+
+const store = configureStore({
+  reducer: {
+    missions: missionsReducer,
+  },
+});
+
+export default store;

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,0 +1,14 @@
+import { createSlice } from '@reduxjs/toolkit';
+import fetchMissions from './missionsApi';
+/* eslint-disable prefer-template */
+
+const slice = createSlice({
+  name: 'counter',
+  initialState: [],
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchMissions.fulfilled, (state, action) => action.payload);
+  },
+});
+
+export default slice.reducer;

--- a/src/redux/missions/missionsApi.js
+++ b/src/redux/missions/missionsApi.js
@@ -1,0 +1,22 @@
+import { createAsyncThunk, createAction } from '@reduxjs/toolkit';
+
+const missionsFetched = createAction('missionFetched');
+/* eslint-disable arrow-body-style */
+const BASE_URL = 'https://api.spacexdata.com/v3/missions';
+
+const fetchMissions = createAsyncThunk(missionsFetched, async () => {
+  const response = await fetch(BASE_URL);
+  const data = await response.json();
+
+  // extract just the needed values
+  const less = data.map(({
+    mission_name: name,
+    description,
+    mission_id: id,
+  }) => ({ name, description, id }));
+
+  console.log(less);
+  return less;
+});
+
+export default fetchMissions;

--- a/src/redux/missions/missionsApi.js
+++ b/src/redux/missions/missionsApi.js
@@ -15,7 +15,6 @@ const fetchMissions = createAsyncThunk(missionsFetched, async () => {
     mission_id: id,
   }) => ({ name, description, id }));
 
-  console.log(less);
   return less;
 });
 


### PR DESCRIPTION
# Hi dear reviewer
- Fetch data from the API missions
- Make sure that the data is fetched only once
- Created slice and async tunk
- I also create the config store, we just need to merge it together

### Issues
#13
 #14

### Making sure the API is only hit if our state is empty
> I keep that console log just to make sure the API is hit the first time

![image](https://user-images.githubusercontent.com/105079888/192610079-34a34832-a965-412f-90d3-b7b20febedf8.png)

### getting just the necessary data from the API

![image](https://user-images.githubusercontent.com/105079888/192610390-76eac09b-813c-40b3-8a15-4c8e75372392.png)

### The store

![image](https://user-images.githubusercontent.com/105079888/192610645-c2ce7d08-3077-4bfc-a4dd-d81c9290c8fb.png)


